### PR TITLE
Add Sharpii Arm properly

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d38c7a167c8399378eabb9231c6645e05d2c4285cb78fd8f499183ba64b94985
-size 246


### PR DESCRIPTION
I believe this should add the Sharpii Arm Binary correctly, instead of the way Git LFS was creating it and causing download issues.